### PR TITLE
Add option to escape HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = function(md, options) {
   options = options || {};
   options.stripListLeaders = options.hasOwnProperty('stripListLeaders') ? options.stripListLeaders : true;
   options.gfm = options.hasOwnProperty('gfm') ? options.gfm : true;
+  options.escapeHtml = options.hasOwnProperty('escapeHtml') ? options.escapeHtml : false;
 
   var output = md;
   try {
@@ -16,6 +17,11 @@ module.exports = function(md, options) {
         .replace(/~~/g, '')
         // Fenced codeblocks
         .replace(/`{3}.*\n/g, '');
+    }
+    if (options.escapeHtml) {
+      output = output.replace(/<(.*?)>/g, '&lt;$1&gt;');
+    } else {
+      output = output.replace(/<(.*?)>/g, '$1');
     }
     output = output
       // Remove HTML tags

--- a/index.js
+++ b/index.js
@@ -24,8 +24,6 @@ module.exports = function(md, options) {
       output = output.replace(/<(.*?)>/g, '$1');
     }
     output = output
-      // Remove HTML tags
-      .replace(/<(.*?)>/g, '$1')
       // Remove setext-style headers
       .replace(/^[=\-]{2,}\s*$/g, '')
       // Remove footnotes?

--- a/test/markdown.md
+++ b/test/markdown.md
@@ -1,6 +1,6 @@
 ## This is a heading ##
 
-This is a paragraph with [a link](http://www.disney.com/).
+This is a <b>bold</b> paragraph with [a link](http://www.disney.com/).
 
 ### This is another heading
 

--- a/test/remove-markdown.js
+++ b/test/remove-markdown.js
@@ -5,10 +5,14 @@ var fs = require('fs'),
     should = require('should'),
     removeMd = require('../'),
     markdown = fs.readFileSync(path.resolve(__dirname, 'markdown.md')).toString(),
-    result = fs.readFileSync(path.resolve(__dirname, 'result.txt')).toString();
+    result = fs.readFileSync(path.resolve(__dirname, 'result.txt')).toString(),
+    result_escaped = fs.readFileSync(path.resolve(__dirname, 'result_escaped.txt')).toString();
 
 describe('remove-markdown', function () {
   it('should remove markdown', function () {
     removeMd(markdown).should.eql(result);
+  });
+  it('should escape HTML when asked', function () {
+    removeMd(markdown, {escapeHtml:true}).should.eql(result_escaped);
   });
 });

--- a/test/result_escaped.txt
+++ b/test/result_escaped.txt
@@ -1,6 +1,6 @@
 This is a heading 
 
-This is a bbold/b paragraph with a link.
+This is a &lt;b&gt;bold&lt;/b&gt; paragraph with a link.
 
 This is another heading
 


### PR DESCRIPTION
I'd like to escape (HTML entity encode) HTML instead of removing the opening and closing brackets.
