### PR TITLE
fixed double formatting bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ module.exports = function(md, options) {
       .replace(/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g, '')
       // Remove atx-style headers
       .replace(/^\#{1,6}\s*([^#]*)\s*(\#{1,6})?/gm, '$1')
-      .replace(/([\*_]{1,3})(\S.*?\S)\1/g, '$2')
+      .replace(/([_]{1,3})(\S.*?\S)\1/g, '$2')
+      .replace(/([\*]{1,3})(\S.*?\S)\1/g, '$2')
       .replace(/(`{3,})(.*?)\1/gm, '$2')
       .replace(/^-{3,}\s*$/g, '')
       .replace(/`(.+?)`/g, '$1')

--- a/test/markdown.md
+++ b/test/markdown.md
@@ -4,6 +4,8 @@ This is a paragraph with [a link](http://www.disney.com/).
 
 ### This is another heading
 
+**this sentence has __double styling__**
+
 In `Getting Started` we set up `something` foo.
 
 * Some list

--- a/test/result.txt
+++ b/test/result.txt
@@ -4,6 +4,8 @@ This is a paragraph with a link.
 
 This is another heading
 
+this sentence has double styling
+
 In Getting Started we set up something foo.
 
 Some list


### PR DESCRIPTION
@stiang currently if a block of text has both boldness AND italic markdown formatting, it won't be correctly stripped. This change should fix it. 
