### PR TITLE
Added stripHTML option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = function(md, options) {
   options = options || {};
   options.listUnicodeChar = options.hasOwnProperty('listUnicodeChar') ? options.listUnicodeChar : false;
   options.stripListLeaders = options.hasOwnProperty('stripListLeaders') ? options.stripListLeaders : true;
+  options.stripHTML = options.hasOwnProperty('stripHTML') ? options.stripHTML : true;
   options.gfm = options.hasOwnProperty('gfm') ? options.gfm : true;
   options.useImgAltText = options.hasOwnProperty('useImgAltText') ? options.useImgAltText : true;
 
@@ -28,9 +29,11 @@ module.exports = function(md, options) {
         // Fenced codeblocks
         .replace(/`{3}.*\n/g, '');
     }
+    if (options.stripHTML) {
+      output = output.replace(/<[^>]*>/g, '')
+    }
+
     output = output
-      // Remove HTML tags
-      .replace(/<[^>]*>/g, '')
       // Remove setext-style headers
       .replace(/^[=\-]{2,}\s*$/g, '')
       // Remove footnotes?

--- a/test/remove-markdown.js
+++ b/test/remove-markdown.js
@@ -33,6 +33,11 @@ describe('remove Markdown', function () {
       expect(removeMd(string)).to.equal(expected);
     });
 
+    it('should not strip HTML if stripHTML=false', function () {
+      const string = '<p>Hello World</p>';
+      expect(removeMd(string, { stripHTML: false })).to.equal(string);
+    });
+
     it('should strip anchors', function () {
       const string = '*Javascript* [developers](https://engineering.condenast.io/)* are the _best_.';
       const expected = 'Javascript developers* are the best.';


### PR DESCRIPTION
- Defaults to `true` or backwards compatibility.
- Considering the main functionality of this library is to strip markdown it makes sense to make stripping html optional.