### PR TITLE
Remove underscore emphasis only on appropriate boundaries

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,9 +46,12 @@ module.exports = function(md, options) {
       .replace(/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g, '')
       // Remove atx-style headers
       .replace(/^(\n)?\s{0,}#{1,6}\s+| {0,}(\n)?\s{0,}#{0,} {0,}(\n)?\s{0,}$/gm, '$1$2$3')
-      // Remove emphasis (repeat the line to remove double emphasis)
-      .replace(/([\*_]{1,3})(\S.*?\S{0,1})\1/g, '$2')
-      .replace(/([\*_]{1,3})(\S.*?\S{0,1})\1/g, '$2')
+      // Remove * emphasis
+      .replace(/([\*]+)(\S)(.*?\S)??\1/g, '$2$3')
+      // Remove _ emphasis. Unlike *, _ emphasis gets rendered only if 
+      //   1. Either there is a whitespace character before opening _ and after closing _.
+      //   2. Or _ is at the start/end of the string.
+      .replace(/(^|[\s\W])([_]+)(\S)(.*?\S)??\2($|[\s\W])/g, '$1$3$4$5')
       // Remove code blocks
       .replace(/(`{3,})(.*?)\1/gm, '$2')
       // Remove inline code

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function(md, options) {
       // Remove _ emphasis. Unlike *, _ emphasis gets rendered only if 
       //   1. Either there is a whitespace character before opening _ and after closing _.
       //   2. Or _ is at the start/end of the string.
-      .replace(/(^|[\s\W])([_]+)(\S)(.*?\S)??\2($|[\s\W])/g, '$1$3$4$5')
+      .replace(/(^|\W)([_]+)(\S)(.*?\S)??\2($|\W)/g, '$1$3$4$5')
       // Remove code blocks
       .replace(/(`{3,})(.*?)\1/gm, '$2')
       // Remove inline code

--- a/test/remove-markdown.js
+++ b/test/remove-markdown.js
@@ -69,6 +69,18 @@ describe('remove Markdown', function () {
       expect(removeMd(string)).to.equal(expected);
     });
 
+    it('should remove emphasis only if there is no space between word and emphasis characters.', function () {
+      const string = 'There should be no _space_, *before* *closing * _ephasis character _.';
+      const expected = 'There should be no space, before *closing * _ephasis character _.';
+      expect(removeMd(string)).to.equal(expected);
+    });
+
+    it('should remove "_" emphasis only if there is space before opening and after closing emphasis characters.', function () {
+      const string = '._Spaces_ _ before_ and _after _ emphasised character results in no emphasis.';
+      const expected = '.Spaces _ before_ and _after _ emphasised character results in no emphasis.';
+      expect(removeMd(string)).to.equal(expected);
+    });
+
     it('should remove double emphasis', function () {
       const string = '**this sentence has __double styling__**';
       const expected = 'this sentence has double styling';


### PR DESCRIPTION
There is a slight difference between _ and *. As _ works only if there is non word character before the opening _ tag and after closing _ tag.

Emphasis matching changes for handling the following scenarios 
### Common for '#' and '*'
| Text     | Remove-Markdown | markdown renderer |   |   |
|----------|-----------------|---------------------|---|---|
| `*s****` | `s*`            | *s****              |   |   |
| `**s **` | `s`             | **s **              |   |   |
| `**_*`   | ``              | **_*                |   |   |
### Specific to '_'. 
| Text     | Remove-Markdown | markdown renderer |   |   |
|----------|-----------------|--------------------------|---|---|
| `a_s_d`  | `asd`           | a_s_d                    |   |   |
| `a _s_d` | `a sd`          | a _s_d                   |   |   |
| `a_s_ d` | `as d`          | a_s_ d                   |   |   |

### Unhandled Scenarios
1. *** or ___
2. I italicized an *I * and it made me *sad*