### PR TITLE
Add optional support for abbreviations markdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = function(md, options) {
   options.stripListLeaders = options.hasOwnProperty('stripListLeaders') ? options.stripListLeaders : true;
   options.gfm = options.hasOwnProperty('gfm') ? options.gfm : true;
   options.useImgAltText = options.hasOwnProperty('useImgAltText') ? options.useImgAltText : true;
+  options.abbr = options.hasOwnProperty('abbr') ? options.abbr : false;
 
   var output = md || '';
 
@@ -19,7 +20,7 @@ module.exports = function(md, options) {
     }
     if (options.gfm) {
       output = output
-        // Header
+      // Header
         .replace(/\n={2,}/g, '\n')
         // Fenced codeblocks
         .replace(/~{3}.*\n/g, '')
@@ -28,8 +29,12 @@ module.exports = function(md, options) {
         // Fenced codeblocks
         .replace(/`{3}.*\n/g, '');
     }
+    if (options.abbr) {
+      // Remove abbreviations
+      output = output.replace(/\*\[.*\]:.*\n/, '');
+    }
     output = output
-      // Remove HTML tags
+    // Remove HTML tags
       .replace(/<[^>]*>/g, '')
       // Remove setext-style headers
       .replace(/^[=\-]{2,}\s*$/g, '')


### PR DESCRIPTION
Abbreviations, `<abbr>`, are a relatively common markdown pattern supported by many markdown renders. This would add support for removing these markdown values, behind a configuration option, `abbr`

`abbr` Markdown Sytnax:
*[word]: Description of the word

Example Usage:
```
const markdown = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

*[Lorem ipsum]: Dummy text of the printing and typesetting industry
`;

const output = removeMarkdown(markdown, {
  abbr: true
}
console.log(output) // "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n"
```

https://python-markdown.github.io/extensions/abbreviations/