### PR TITLE
Multiline blockquote removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function(md, options) {
       // Remove inline links
       .replace(/\[(.*?)\][\[\(].*?[\]\)]/g, '$1')
       // Remove blockquotes
-      .replace(/^\s{0,3}>\s?/g, '')
+      .replace(/^\s{0,3}>\s?/gm, '')
       // Remove reference-style links?
       .replace(/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g, '')
       // Remove atx-style headers

--- a/test/remove-markdown.js
+++ b/test/remove-markdown.js
@@ -109,6 +109,12 @@ describe('remove Markdown', function () {
             expect(removeMd(test.string)).to.equal(test.expected);
         });
     });
+    
+    it('should remove blockquotes over multiple lines', function () {
+      const string = '> I am a blockquote firstline  \n>I am a blockquote secondline';
+      const expected = 'I am a blockquote firstline\nI am a blockquote secondline';
+      expect(removeMd(string)).to.equal(expected);
+    });
 
     it('should not remove greater than signs', function () {
       var tests = [


### PR DESCRIPTION
Previously this scenario:
```
> I am a blockquote firstline  
> I am a blockquote secondline
```
returned the following when `removeMd` was run against it
```
I am a blockquote firstline
> I am a blockquote secondline
```
Thereby failing to remove the second `> `.
This PR resolves that scenario and adds a test to cover it.
