### PR TITLE
Do not strip ending hashes without content (paragraphs)

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function(md, options) {
       // Remove reference-style links?
       .replace(/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g, '')
       // Remove atx-style headers
-      .replace(/^(\n)?\s{0,}#{1,6}\s+| {0,}(\n)?\s{0,}#{0,} {0,}(\n)?\s{0,}$/gm, '$1$2$3')
+      .replace(/^(\n)?\s{0,}#{1,6}\s+| {0,}(\n)?\s{0,}#{0,} #{0,}(\n)?\s{0,}$/gm, '$1$2$3')
       // Remove emphasis (repeat the line to remove double emphasis)
       .replace(/([\*_]{1,3})(\S.*?\S{0,1})\1/g, '$2')
       .replace(/([\*_]{1,3})(\S.*?\S{0,1})\1/g, '$2')

--- a/test/remove-markdown.js
+++ b/test/remove-markdown.js
@@ -141,5 +141,11 @@ describe('remove Markdown', function () {
       const expected = '\nThis is a heading\n\nThis is a paragraph with a link.\n\nThis is another heading\n\nIn Getting Started we set up something foo.\n\n  Some list\n  With items\n    Even indented';
       expect(removeMd(paragraph)).to.equal(expected);
     });
+
+    it('should not strip paragraphs without content', function() {
+      const paragraph = '\n#This paragraph\n##This paragraph#';
+      const expected = paragraph;
+      expect(removeMd(paragraph)).to.equal(expected);
+    });
   });
 });


### PR DESCRIPTION
The existing code is stripping out ending hashes when it shouldn't.

For example:
```
# The code of my gate is: 123# 
```

Gets converted to:
```
# The code of my gate is: 123 
```