### PR TITLE
chore(ci): update node versions in default workflow

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Update node versions in default workflow to current LTS releases.

Also including the current release could be added as well with something a little more verbose like:

```yaml
    strategy:
      matrix:
        include:
          - node-version: 14
            lts: true
          - node-version: 16
            lts: true
          - node-version: 18
            lts: false
          - node-version: 19
            lts: false
    continue-on-error: ${{ ! matrix.lts }}
```