### PR TITLE
Performance: Move regex initializations to module scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,26 @@
+// Regex-Konstrukte in den äußeren Scope verschoben
+const HR_REGEX = /^ {0,3}((?:-[\t ]*){3,}|(?:_[ \t]*){3,}|(?:\*[ \t]*){3,})(?:\n+|$)/gm;
+const LIST_LEADER_REGEX = /^([\s\t]*)([\*\-\+]|\d+\.)\s+/gm;
+const HEADER_UNDERLINE_REGEX = /\n={2,}/g;
+const FENCED_CODEBLOCK_TILDE_REGEX = /~{3}.*\n/g;
+const STRIKETHROUGH_REGEX = /~~/g;
+const FENCED_CODEBLOCK_BACKTICK_REGEX = /```(?:.*)\n([\s\S]*?)```/g;
+const ABBR_REGEX = /\*\[.*\]:.*\n/;
+const HTML_TAGS_REGEX = /<[^>]*>/g;
+const SETEXT_HEADER_REGEX = /^[=\-]{2,}\s*$/g;
+const FOOTNOTE_REGEX = /\[\^.+?\](\: .*?$)?/g;
+const FOOTNOTE_LINK_REGEX = /\s{0,2}\[.*?\]: .*?$/g;
+const IMAGE_REGEX = /!\[(.*?)\][\[\(].*?[\]\)]/g;
+const INLINE_LINK_REGEX = /\[([\s\S]*?)\]\s*[\(\[].*?[\)\]]/g;
+const BLOCKQUOTE_REGEX = /^(\n)?\s{0,3}>\s?/gm;
+const REF_LINK_REGEX = /^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g;
+const ATX_HEADER_REGEX = /^(\n)?\s{0,}#{1,6}\s*( (.+))? +#+$|^(\n)?\s{0,}#{1,6}\s*( (.+))?$/gm;
+const EMPHASIS_ASTERISK_REGEX = /([\*]+)(\S)(.*?\S)??\1/g;
+const EMPHASIS_UNDERSCORE_REGEX = /(^|\W)([_]+)(\S)(.*?\S)??\2($|\W)/g;
+const MULTILINE_CODEBLOCK_REGEX = /(`{3,})(.*?)\1/gm;
+const INLINE_CODE_REGEX = /`(.+?)`/g;
+const STRIKE_REGEX = /~(.*?)~/g;
+
 module.exports = function(md, options) {
   options = options || {};
   options.listUnicodeChar = options.hasOwnProperty('listUnicodeChar') ? options.listUnicodeChar : false;
@@ -12,37 +35,37 @@ module.exports = function(md, options) {
   var output = md || '';
 
   // Remove horizontal rules (stripListHeaders conflict with this rule, which is why it has been moved to the top)
-  output = output.replace(/^ {0,3}((?:-[\t ]*){3,}|(?:_[ \t]*){3,}|(?:\*[ \t]*){3,})(?:\n+|$)/gm, '');
+  output = output.replace(HR_REGEX, '');
 
   try {
     if (options.stripListLeaders) {
       if (options.listUnicodeChar)
-        output = output.replace(/^([\s\t]*)([\*\-\+]|\d+\.)\s+/gm, options.listUnicodeChar + ' $1');
+        output = output.replace(LIST_LEADER_REGEX, options.listUnicodeChar + ' $1');
       else
-        output = output.replace(/^([\s\t]*)([\*\-\+]|\d+\.)\s+/gm, '$1');
+        output = output.replace(LIST_LEADER_REGEX, '$1');
     }
     if (options.gfm) {
       output = output
       // Header
-        .replace(/\n={2,}/g, '\n')
+        .replace(HEADER_UNDERLINE_REGEX, '\n')
         // Fenced codeblocks
-        .replace(/~{3}.*\n/g, '')
+        .replace(FENCED_CODEBLOCK_TILDE_REGEX, '')
         // Strikethrough
-        .replace(/~~/g, '')
+        .replace(STRIKETHROUGH_REGEX, '')
         // Fenced codeblocks with backticks
-        .replace(/```(?:.*)\n([\s\S]*?)```/g, (_, code) => code.trim());
+        .replace(FENCED_CODEBLOCK_BACKTICK_REGEX, (_, code) => code.trim());
     }
     if (options.abbr) {
       // Remove abbreviations
-      output = output.replace(/\*\[.*\]:.*\n/, '');
+      output = output.replace(ABBR_REGEX, '');
     }
     
-    let htmlReplaceRegex = /<[^>]*>/g
+    let htmlReplaceRegex = HTML_TAGS_REGEX;
     if (options.htmlTagsToSkip && options.htmlTagsToSkip.length > 0) {
       // Create a regex that matches tags not in htmlTagsToSkip
       const joinedHtmlTagsToSkip = options.htmlTagsToSkip.join('|')
       htmlReplaceRegex = new RegExp(
-        `<(?!\/?(${joinedHtmlTagsToSkip})(?=>|\s[^>]*>))[^>]*>`,
+        `<(?!/?(${joinedHtmlTagsToSkip})(?=>|\s[^>]*>))[^>]*>`,
         'g',
       )
     }
@@ -51,37 +74,37 @@ module.exports = function(md, options) {
       // Remove HTML tags
       .replace(htmlReplaceRegex, '')
       // Remove setext-style headers
-      .replace(/^[=\-]{2,}\s*$/g, '')
+      .replace(SETEXT_HEADER_REGEX, '')
       // Remove footnotes?
-      .replace(/\[\^.+?\](\: .*?$)?/g, '')
-      .replace(/\s{0,2}\[.*?\]: .*?$/g, '')
+      .replace(FOOTNOTE_REGEX, '')
+      .replace(FOOTNOTE_LINK_REGEX, '')
       // Remove images
-      .replace(/\!\[(.*?)\][\[\(].*?[\]\)]/g, options.useImgAltText ? '$1' : '')
+      .replace(IMAGE_REGEX, options.useImgAltText ? '$1' : '')
       // Remove inline links
-      .replace(/\[([\s\S]*?)\]\s*[\(\[].*?[\)\]]/g, options.replaceLinksWithURL ? '$2' : '$1')
+      .replace(INLINE_LINK_REGEX, options.replaceLinksWithURL ? '$2' : '$1')
       // Remove blockquotes
-      .replace(/^(\n)?\s{0,3}>\s?/gm, '$1')
+      .replace(BLOCKQUOTE_REGEX, '$1')
       // .replace(/(^|\n)\s{0,3}>\s?/g, '\n\n')
       // Remove reference-style links?
-      .replace(/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g, '')
+      .replace(REF_LINK_REGEX, '')
       // Remove atx-style headers
-      .replace(/^(\n)?\s{0,}#{1,6}\s*( (.+))? +#+$|^(\n)?\s{0,}#{1,6}\s*( (.+))?$/gm, '$1$3$4$6')
+      .replace(ATX_HEADER_REGEX, '$1$3$4$6')
       // Remove * emphasis
-      .replace(/([\*]+)(\S)(.*?\S)??\1/g, '$2$3')
+      .replace(EMPHASIS_ASTERISK_REGEX, '$2$3')
       // Remove _ emphasis. Unlike *, _ emphasis gets rendered only if 
       //   1. Either there is a whitespace character before opening _ and after closing _.
       //   2. Or _ is at the start/end of the string.
-      .replace(/(^|\W)([_]+)(\S)(.*?\S)??\2($|\W)/g, '$1$3$4$5')
+      .replace(EMPHASIS_UNDERSCORE_REGEX, '$1$3$4$5')
       // Remove single-line code blocks (already handled multiline above in gfm section)
-      .replace(/(`{3,})(.*?)\1/gm, '$2')
+      .replace(MULTILINE_CODEBLOCK_REGEX, '$2')
       // Remove inline code
-      .replace(/`(.+?)`/g, '$1')
+      .replace(INLINE_CODE_REGEX, '$1')
       // // Replace two or more newlines with exactly two? Not entirely sure this belongs here...
       // .replace(/\n{2,}/g, '\n\n')
       // // Remove newlines in a paragraph
       // .replace(/(\S+)\n\s*(\S+)/g, '$1 $2')
       // Replace strike through
-      .replace(/~(.*?)~/g, '$1');
+      .replace(STRIKE_REGEX, '$1');
   } catch(e) {
     if (options.throwError) throw e;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remove-markdown",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remove-markdown",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "devDependencies": {
         "chai": "^4.0.2",


### PR DESCRIPTION
Description:

This PR moves all regular expression initializations in [index.js](https://github.com/zuchka/remove-markdown/compare/main...kulturpessimist:remove-markdown:main?expand=1) to the module (outer) scope, so they are only created once and reused on every function call. This improves performance, especially when the function is called frequently.

All regex patterns are now declared as constants at the top of the file
No change in functionality; all tests continue to pass
Motivation: Previously, regex objects were re-initialized on every function call, which could impact performance. With this change, regex objects are created once and reused.

Tests: All existing tests (npm test) pass successfully.

As requested with proposal from @punkpeye