### PR TITLE
Replace inline link with its text, a separator and its link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ You can also supply an options object to the function. Currently, the following 
 
 ```js
 const plainText = removeMd(markdown, {
-  stripListLeaders: true , // strip list leaders (default: true)
-  listUnicodeChar: '',     // char to insert instead of stripped list leaders (default: '')
-  gfm: true                // support GitHub-Flavored Markdown (default: true)
-  useImgAltText: true      // replace images with alt-text, if present (default: true)
+  stripListLeaders: true ,     // strip list leaders (default: true)
+  listUnicodeChar: '',         // char to insert instead of stripped list leaders (default: '')
+  gfm: true,                   // support GitHub-Flavored Markdown (default: true)
+  useImgAltText: true,         // replace images with alt-text, if present (default: true)
+  abbr: true,                  // remove abbreviations, if present (default: false)
+  replaceLinksWithURL: true,   // remove inline links, if present (default: false)
+  separateLinksAndTexts: ': ', // replace inline links with text, separator and link, if present (default: null)
+  htmlTagsToSkip: ['a', 'b']   // HTML tags to skip, if present (default: [])
 });
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ declare function removeMd(md: string, options?: {
   useImgAltText: boolean;
   abbr?: boolean;
   replaceLinksWithURL?: boolean;
+  separateLinksAndTexts?: string;
   htmlTagsToSkip?: string[];
 }): string;
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = function(md, options) {
   options.useImgAltText = options.hasOwnProperty('useImgAltText') ? options.useImgAltText : true;
   options.abbr = options.hasOwnProperty('abbr') ? options.abbr : false;
   options.replaceLinksWithURL = options.hasOwnProperty('replaceLinksWithURL') ? options.replaceLinksWithURL : false;
+  options.separateLinksAndTexts = options.hasOwnProperty('separateLinksAndTexts') ? options.separateLinksAndTexts : null;
   options.htmlTagsToSkip = options.hasOwnProperty('htmlTagsToSkip') ? options.htmlTagsToSkip : [];
   options.throwError = options.hasOwnProperty('throwError') ? options.throwError : false;
 
@@ -36,7 +37,7 @@ module.exports = function(md, options) {
       // Remove abbreviations
       output = output.replace(/\*\[.*\]:.*\n/, '');
     }
-    
+
     let htmlReplaceRegex = /<[^>]*>/g
     if (options.htmlTagsToSkip && options.htmlTagsToSkip.length > 0) {
       // Create a regex that matches tags not in htmlTagsToSkip
@@ -45,6 +46,10 @@ module.exports = function(md, options) {
         `<(?!\/?(${joinedHtmlTagsToSkip})(?=>|\s[^>]*>))[^>]*>`,
         'g',
       )
+    }
+
+    if (options.separateLinksAndTexts) {
+      output = output.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1' + options.separateLinksAndTexts + '$2');
     }
 
     output = output
@@ -68,7 +73,7 @@ module.exports = function(md, options) {
       .replace(/^(\n)?\s{0,}#{1,6}\s*( (.+))? +#+$|^(\n)?\s{0,}#{1,6}\s*( (.+))?$/gm, '$1$3$4$6')
       // Remove * emphasis
       .replace(/([\*]+)(\S)(.*?\S)??\1/g, '$2$3')
-      // Remove _ emphasis. Unlike *, _ emphasis gets rendered only if 
+      // Remove _ emphasis. Unlike *, _ emphasis gets rendered only if
       //   1. Either there is a whitespace character before opening _ and after closing _.
       //   2. Or _ is at the start/end of the string.
       .replace(/(^|\W)([_]+)(\S)(.*?\S)??\2($|\W)/g, '$1$3$4$5')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remove-markdown",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remove-markdown",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "devDependencies": {
         "chai": "^4.0.2",

--- a/test/remove-markdown.js
+++ b/test/remove-markdown.js
@@ -62,13 +62,13 @@ describe('remove Markdown', function () {
       const expected = 'code';
       expect(removeMd(string)).to.equal(expected);
     });
-    
+
     it('should strip complex multiline code blocks with language specified', function () {
       const string = '```javascript\nconst x = 1;\nconst y = 2;\nconsole.log(x + y);\n```';
       const expected = 'const x = 1;\nconst y = 2;\nconsole.log(x + y);';
       expect(removeMd(string)).to.equal(expected);
     });
-    
+
     it('should strip multiline code blocks with multiple paragraphs', function () {
       const string = 'Text before\n\n```\ncode line 1\n\ncode line 2\n```\n\nText after';
       const expected = 'Text before\n\ncode line 1\n\ncode line 2\n\nText after';
@@ -145,7 +145,7 @@ describe('remove Markdown', function () {
             expect(removeMd(test.string)).to.equal(test.expected);
         });
     });
-    
+
     it('should remove blockquotes over multiple lines', function () {
       const string = '> I am a blockquote firstline  \n>I am a blockquote secondline';
       const expected = 'I am a blockquote firstline  \nI am a blockquote secondline';
@@ -248,5 +248,11 @@ describe('remove Markdown', function () {
         'HTML content <sub>Superscript</sub> <span>span text</span>',
       )
     })
+
+    it('should replace inline link with text and link, with separator', function () {
+      const string = 'some [inline link](http://www.disney.com/).';
+      const expected = 'some inline link: http://www.disney.com/.';
+      expect(removeMd(string, {separateLinksAndTexts: ': '})).to.equal(expected);
+    });
   });
 });


### PR DESCRIPTION
This PR adds the possibility to replace inline links with text and link.

It adds a new option `separateLinksAndTexts` which is `null` by default, and is the separator between text and link.

```javascript
it('should replace inline link with text and link, with separator', function () {
  const string = 'some [inline link](http://www.test.net/).';
  const expected = 'some inline link: http://www.test.net/.';
  expect(removeMd(string, { separateLinksAndTexts: ': ' })).to.equal(expected);
});
```

Addresses #100 