### PR TITLE
Add missing group for links replace regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function(md, options) {
       // Remove images
       .replace(/\!\[(.*?)\][\[\(].*?[\]\)]/g, options.useImgAltText ? '$1' : '')
       // Remove inline links
-      .replace(/\[([\s\S]*?)\]\s*[\(\[].*?[\)\]]/g, options.replaceLinksWithURL ? '$2' : '$1')
+      .replace(/\[([\s\S]*?)\]\s*[\(\[](.*?)[\)\]]/g, options.replaceLinksWithURL ? '$2' : '$1')
       // Remove blockquotes
       .replace(/^(\n)?\s{0,3}>\s?/gm, '$1')
       // .replace(/(^|\n)\s{0,3}>\s?/g, '\n\n')

--- a/test/remove-markdown.js
+++ b/test/remove-markdown.js
@@ -209,6 +209,12 @@ describe('remove Markdown', function () {
       expect(removeMd(string)).to.equal(expected);
     });
 
+    it('should keep url instead of text when replaceLinksWithURL is enabled', function () {
+      const string = 'This is a [link](http://www.disney.com/).';
+      const expected = 'This is a http://www.disney.com/.';
+      expect(removeMd(string, { replaceLinksWithURL: true })).to.equal(expected);
+    });
+
     it('should not strip paragraphs without content', function() {
       const paragraph = '\n#This paragraph\n##This paragraph#';
       const expected = paragraph;


### PR DESCRIPTION
Added missing group for RegExp when `replaceLinksWithUrl` option is enabled.
fixes #103