### PR TITLE
Mark useImgAltText parameter as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare function removeMd(md: string, options?: {
   stripListLeaders?: boolean;
   listUnicodeChar?: string;
   gfm?: boolean;
-  useImgAltText: boolean;
+  useImgAltText?: boolean;
   abbr?: boolean;
   replaceLinksWithURL?: boolean;
   separateLinksAndTexts?: string;


### PR DESCRIPTION
Is the `useImgAltText` parameter supposed to be required?
Currently it's not possible to pass an empty `options` object, even though it's a functional equivalent to passing nothing at all.

<img width="1295" height="366" alt="image" src="https://github.com/user-attachments/assets/18bfbc86-47f0-46db-a78a-7ddeb7dd918a" />

This PR just changes the types so the parameter is optional.

Let me know what you think.
Have a great day. 🙏