### PR TITLE
feat: strip MDX imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ module.exports = function(md, options) {
       )
     }
 
+    let importReplaceRegex = /^import\s+([a-zA-Z0-9{}\-_,* /]+from)?\s*["'][^'"]+["'];?$\n+/gm
+
     if (options.separateLinksAndTexts) {
       output = output.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1' + options.separateLinksAndTexts + '$2');
     }
@@ -55,6 +57,8 @@ module.exports = function(md, options) {
     output = output
       // Remove HTML tags
       .replace(htmlReplaceRegex, '')
+      // Remove import statements
+      .replace(importReplaceRegex, '')
       // Remove setext-style headers
       .replace(/^[=\-]{2,}\s*$/g, '')
       // Remove footnotes?

--- a/test/remove-markdown.js
+++ b/test/remove-markdown.js
@@ -33,6 +33,18 @@ describe('remove Markdown', function () {
       expect(removeMd(string)).to.equal(expected);
     });
 
+    it('should strip MDX import statements', function () {
+      const tests = [
+        { string: 'import page404 from "@/assets/images/404.png"\n\nHere is some text', expected: 'Here is some text' },
+        { string: 'import "mycomponent.astro";\nWelcome back!', expected: 'Welcome back!' },
+        { string: "import { Validator as val } from '../util.js'\nSuper imports?", expected: 'Super imports?' },
+        { string: 'import page404 from "@/assets/images/404.png";\nimport page403 from "@/assets/images/403.png";\n\nSome errors, huh', expected: 'Some errors, huh' },
+      ];
+      tests.forEach(function (test) {
+        expect(removeMd(test.string)).to.equal(test.expected);
+      });
+    })
+
     it('should strip anchors', function () {
       const string = '*Javascript* [developers](https://engineering.condenast.io/)* are the _best_.';
       const expected = 'Javascript developers* are the best.';


### PR DESCRIPTION
In extended markdown syntax (MDX), you can have JS-style import statements at the top of the file. Currently, with `remove-markdown`, these are included in the output, which makes post previews basically useless.

<img width="1272" height="200" alt="image" src="https://github.com/user-attachments/assets/1266b192-a7ee-4e15-afcd-efc7eb7f46e6" />

This PR changes that by adding a regex that checks for import statements and removes these. The regex ensures that the import statement does not contain leading characters and ends in at least one newline (trailing newlines are removed so the content part starts instantly, as if the newline was never there). This is technically more restrictive than the real limitations of JS-style imports, but seemed to me like a respectable limitation.

---

The regex is kept very simple and does not check for exact import syntax; it primarily just checks for the `import` keyword and any combination of the valid characters.

---

I've added the following test case:
```js
it('should strip MDX import statements', function () {
  const tests = [
    { string: 'import page404 from "@/assets/images/404.png"\n\nHere is some text', expected: 'Here is some text' },
    { string: 'import "mycomponent.astro";\nWelcome back!', expected: 'Welcome back!' },
    { string: "import { Validator as val } from '../util.js'\nSuper imports?", expected: 'Super imports?' },
    { string: 'import page404 from "@/assets/images/404.png";\nimport page403 from "@/assets/images/403.png";\n\nSome errors, huh', expected: 'Some errors, huh' },
  ];
  tests.forEach(function (test) {
    expect(removeMd(test.string)).to.equal(test.expected);
  });
})
```

It checks for a few common variants of import statements.

---

Let me know if there's anything missing or if I should restrict the regex further. Alternatively **Allow edits by maintainers** is enabled, so the PR can be edited to fix code smells.